### PR TITLE
Update documentation and deprecate TypoScript conditioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/Resources/Public/Contrib/
+.idea/

--- a/Classes/Condition/HttpReferer.php
+++ b/Classes/Condition/HttpReferer.php
@@ -6,6 +6,12 @@ namespace RaccoonDepot\RdContactPlugin\Condition;
 use TYPO3\CMS\Core\Configuration\TypoScript\ConditionMatching\AbstractCondition;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
+/**
+ * Class HttpReferer
+ * @deprecated since 1.1.0, will be removed in 2.x.
+ * As conditioning feature is not based on TS anymore.
+ * If you still need it, please implement it on your side.
+ */
 class HttpReferer extends AbstractCondition
 {
     /**
@@ -25,7 +31,7 @@ class HttpReferer extends AbstractCondition
 
                     if( isset($_SERVER['HTTP_REFERER']) ) {
                         $value = trim( $value );
-                        
+
                         switch ($value[0]) {
                             case '=':
                                 // exactly
@@ -48,13 +54,13 @@ class HttpReferer extends AbstractCondition
                                 }
 
                                 break;
-                            
+
                             default:
                                 return false;
                                 break;
                         }
                         // end
-                    } 
+                    }
                     else {
                         return false;
                     }

--- a/README.md
+++ b/README.md
@@ -1,29 +1,35 @@
-## RD Contact form plugin ##
-<b>RD Contact Plugin</b> is an extension developed by <a href="http://www.raccoondepot.com/">Raccoon Depot</a> team to be used in TYPO3 CMS 9+ or higher. This plugin includes simple contact button on each website page, and provides different ways for communication between website visitors and website owner. <br/>
-An extension is flexible, so you could configure it as you wish. There are implemented very flexible restrictions where you can manipulate contact options dynamically based on that restrictions<br />
-Also we developed custom TS condition which can be used to run different configurations depends on HTTP_REFERER header. How HTTP_REFERER could help you in business, you can read here: <a href="https://www.lifewire.com/how-to-use-http-referer-3471200#mntl-sc-block_1-0-33">https://www.lifewire.com/how-to-use-http-referer-3471200#mntl-sc-block_1-0-33</a>. To see all available options/configurations and how to start read further..
+<b>raccoondepot/rd-contact-plugin</b> - is an extension built for TYPO3 CMS 9+ which displays on your website simple 
+contact button (you can choose the position), and by click on it user see different contact options. 
+Plugin is very flexible thus you can configure contact options for different situations as you wish! 
+Also you can create particular contact option which by choosing it will open modal window and there you can 
+insert any content element you would like, e.g contact form :)
 
-## Contact Options ##
-First you need to create plugin configuration in any storage folder, then attach needed contact options.
+Also, it is possible to set restrictions in specific contact options so they would appear on the frontend 
+only when such restrictions matches
 
-## How to install ##
-1. add git@gitlab.com:raccoondepot/rd_contact_plugin.git to repositories in your composer.json file
-2. add "raccoondepot/rd-contact-plugin" in require section in your composer.json file
-3. composer update raccoondepot/rd-contact-plugin
-4. make sure rd_contact_plugin enabled in Extension Manager
-5. add TS static includes
-6. create new plugin configuration under any storage folder and add needed contact options
-7. clear cache
+Next restrictions are implemented:
+- PID (display contact option only if current page match the selected ones in restriction)
+- HTTP_REFERER (display contact option only if HTTP_REFERER contains specific value set in restriction). How such options could help you in business? here is an article: https://www.lifewire.com/how-to-use-http-referer-3471200#mntl-sc-block_1-0-33
 
-## How to configure ##
 
-### Contact options ###
+## How to install? ##
+- composer require raccoondepot/rd-contact-plugin
+- include TypoScript of an extension
+- flush the cache
 
-### Typoscript variables ###
-Plugin can be configured by TypoScript constants. They can be found under <b>plugin.tx_rdcontactplugin.settings</b> Here is the list of all available options:
 
-#### Main ####
-<!-- Main -->
+## How to get started? ##
+- first create plugin configuration record in any storage folder
+- create any combination of contact options in it 
+- use any restriction to setup some dynamic behavior
+- save and flush the cache
+- check the frontend
+
+
+### TypoScript settings ###
+Beside settings in database configuration record you have few more options in TypoScript. 
+They can be found under <b>plugin.tx_rdcontactplugin.settings</b> Here is the list of all available options:
+
 <table style="width: 100%;">
     <thead>
         <tr>
@@ -36,7 +42,7 @@ Plugin can be configured by TypoScript constants. They can be found under <b>plu
     <tbody>
         <tr>
             <td>enabled</td>
-            <td>Is the whole plugin enabled?</td>
+            <td>Is the whole plugin enabled? (Global enable/disable)</td>
             <td>1</td>
             <td>1/0</td>
         </tr>
@@ -49,8 +55,10 @@ Plugin can be configured by TypoScript constants. They can be found under <b>plu
     </tbody>
 </table>
 
-### Typoscript conditions ###
-We have developed custom typoscript condition which you can use to have different contact plugin configuration depending on where website visitor came from. How such options could help you in business? here is an article: https://www.lifewire.com/how-to-use-http-referer-3471200#mntl-sc-block_1-0-33
+
+### TypoScript HTTP_REFERER condition ###
+
+We've developed TypoScript condition which you can use to have different behaviour of your website depending on where website visitor came from (HTTP_REFERER). 
 
 <table style="width: 100%;">
     <thead>
@@ -93,25 +101,15 @@ We have developed custom typoscript condition which you can use to have differen
     </tbody>
 </table>
 
-Also do not forget about another TYPO3 TS conditions: https://docs.typo3.org/typo3cms/TyposcriptReference/7.6/Conditions/Reference/Index.html
 
-## Known issues ##
-In case of any issue please inform us by depot@raccoondepot.com
+## AUTHORS ##
 
-## Future improvements ##
-In future we plan to bring more contact options.
-
-<div style="text-align: center;">
-<h1>Authors</h1>
-<a href="http://www.raccoondepot.com/" target="_blank">
-    <img src="https://www.raccoondepot.com/themes/fe_layout_rd/assets/images/logo/raccoon-depot-logo.svg" width="200" style="width: 200px; height: auto;">
-</a><br />
-<a href="http://www.raccoondepot.com/" target="_blank">
-    Raccoon Depot
-</a><br />
+<a href="https://www.linkedin.com/in/rostyslav-matviyiv/" target="_blank">Rostyslav Matviyiv</a><br />
+Yaroslav Trach<br />
+<br />
 <a href="mailto:depot@raccoondepot.com">
     depot@raccoondepot.com
 </a><br />
-<a href="https://www.facebook.com/profile.php?id=100004945534421" target="_blank">
-    Rostyslav Matviyiv</a>, Yaroslav Trach, Andrii Pozdieiev<br />
-</div>
+<a href="http://www.raccoondepot.com/" target="_blank">
+    <img src="https://www.raccoondepot.com/themes/fe_layout_rd/assets/images/logo/raccoon-depot-logo.svg" width="200" style="width: 200px; height: auto;">
+</a><br />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <b>raccoondepot/rd-contact-plugin</b> - is an extension built for TYPO3 CMS 9+ which displays on your website simple 
 contact button (you can choose the position), and by click on it user see different contact options. 
-Plugin is very flexible thus you can configure contact options for different situations as you wish! 
+Plugin is very flexible thus you can configure contact options exactly for your needs! 
 Also you can create particular contact option which by choosing it will open modal window and there you can 
 insert any content element you would like, e.g contact form :)
 
@@ -52,11 +52,17 @@ They can be found under <b>plugin.tx_rdcontactplugin.settings</b> Here is the li
             <td>bottom_right</td>
             <td>bottom_left / top_left / top_right / bottom_right</td>
         </tr>
+        <tr>
+            <td>pluginToUseUid</td>
+            <td>Do you wanna use specific plugin configurations?</td>
+            <td>-</td>
+            <td>UID of the configuration record</td>
+        </tr>
     </tbody>
 </table>
 
 
-### TypoScript HTTP_REFERER condition ###
+### [DEPRECATED] TypoScript HTTP_REFERER condition ###
 
 We've developed TypoScript condition which you can use to have different behaviour of your website depending on where website visitor came from (HTTP_REFERER). 
 
@@ -101,15 +107,24 @@ We've developed TypoScript condition which you can use to have different behavio
     </tbody>
 </table>
 
+## Do you have any questions? ##
+
+Please contact us by <a href="mailto:depot@raccoondepot.com">depot@raccoondepot.com</a>, 
+or use *Discussions* section on <a href="https://github.com/raccoondepot/rd-contact-plugin">GitHub</a> page  
+
+## Report an issue ##
+
+Please contact us by <a href="mailto:depot@raccoondepot.com">depot@raccoondepot.com</a>, 
+or use *Discussions* section on <a href="https://github.com/raccoondepot/rd-contact-plugin">GitHub</a> page                   
 
 ## AUTHORS ##
 
-<a href="https://www.linkedin.com/in/rostyslav-matviyiv/" target="_blank">Rostyslav Matviyiv</a><br />
-Yaroslav Trach<br />
+<a href="https://www.linkedin.com/in/rostyslav-matviyiv/" target="_blank">Rostyslav Matviyiv</a> (BE)<br />
+Yaroslav Trach (FE)<br />
 <br />
 <a href="mailto:depot@raccoondepot.com">
     depot@raccoondepot.com
 </a><br />
-<a href="http://www.raccoondepot.com/" target="_blank">
+<a href="https://www.raccoondepot.com/" target="_blank">
     <img src="https://www.raccoondepot.com/themes/fe_layout_rd/assets/images/logo/raccoon-depot-logo.svg" width="200" style="width: 200px; height: auto;">
 </a><br />

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,56 @@
 {
   "name": "raccoondepot/rd-contact-plugin",
-  "description": "Deploy beautiful embed contact form on your website",
-  "type": "typo3-cms-extension",
   "version": "1.1.0",
+  "type": "typo3-cms-extension",
+  "description": "Flexible frontend contact plugin for TYPO3 CMS",
+  "homepage": "https://raccoondepot.com",
+  "keywords": [
+    "TYPO3",
+    "extension",
+    "contact",
+    "communication",
+    "plugin"
+  ],
+  "authors": [
+    {
+      "name": "Rostyslav Matviiv",
+      "role": "Backend Developer"
+    },
+    {
+      "name": "Yaroslav Trach",
+      "role": "Frontend Developer"
+    }
+  ],
   "prefer-stable": true,
-  "keywords": ["TYPO3 CMS", "rd_contact_plugin"],
-  "license": "GPL-2.0+",
+  "license": [
+    "GPL-2.0-or-later"
+  ],
   "require": {
-    "typo3/cms-core": "^9.0 || dev-master",
-    "typo3/cms-backend": "^9.0 || dev-master",
-    "typo3/cms-recordlist": "^9.0 || dev-master",
-    "typo3/cms-frontend": "^9.0 || dev-master",
+    "typo3/cms-core": "^9.5",
     "php": "^7.1"
   },
   "replace": {
-    "rd_contact_plugin": "self.version"
+    "typo3-ter/rd_contact_plugin": "self.version"
   },
   "autoload": {
     "psr-4": {
       "RaccoonDepot\\RdContactPlugin\\": "Classes"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "RaccoonDepot\\RdContactPlugin\\Tests\\": "Tests"
+    }
+  },
+  "config": {
+    "vendor-dir": ".Build/vendor",
+    "bin-dir": ".Build/bin"
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "rd_contact_plugin",
+      "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "web-dir": ".Build/Web"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "raccoondepot/rd-contact-plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "typo3-cms-extension",
   "description": "Flexible frontend contact plugin for TYPO3 CMS",
   "homepage": "https://raccoondepot.com",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,26 +1,20 @@
 <?php
 
-/***************************************************************
- * Extension Manager/Repository config file for ext: "rd_contact_plugin"
- ***************************************************************/
-
 $EM_CONF[$_EXTKEY] = [
-  'title' => 'Contact Plugin',
-  'description' => 'Deploy beautiful embed contact form on your website',
-  'category' => 'plugin',
-  'author' => 'Rostyslav Matviyiv, Yaroslav Trach, Andrii Pozdieiev',
-  'author_email' => 'depot@raccoondepot.com',
-  'state' => 'stable',
-  'internal' => '',
-  'uploadfolder' => '1',
-  'createDirs' => '',
-  'clearCacheOnLoad' => 1,
-  'version' => '1.1.0',
-  'constraints' => [
-      'depends' => [
-          'typo3' => '9.0.0-9.5.99'
-      ],
-      'conflicts' => [],
-      'suggests' => [],
-  ],
+    'title' => 'Contact Plugin',
+    'version' => '1.1.0',
+    'description' => 'Flexible frontend contact plugin for TYPO3 CMS',
+    'category' => 'fe',
+    'author' => 'Rostyslav Matviiv, Yaroslav Trach',
+    'author_email' => 'depot@raccoondepot.com',
+    'state' => 'stable',
+    'clearCacheOnLoad' => true,
+    'createDirs' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '9.0.0-9.5.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
 ];

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Contact Plugin',
-    'version' => '1.1.0',
+    'version' => '1.2.0',
     'description' => 'Flexible frontend contact plugin for TYPO3 CMS',
     'category' => 'fe',
     'author' => 'Rostyslav Matviiv, Yaroslav Trach',


### PR DESCRIPTION
1) Documentation and README.md should be updated to respect current code state.
2) We should deprecate TypoScript conditions like HTTP_REFERER as we're not going to use this approach in the future thus we won't maintain it.
3) Prepare the code to be released into https://extensions.typo3.org and https://packagist.org